### PR TITLE
fix(ui): resolve KeyboardAvoidingView layout resizing bug

### DIFF
--- a/app/(preGameConfig)/_layout.tsx
+++ b/app/(preGameConfig)/_layout.tsx
@@ -5,9 +5,9 @@ import { PageHeading } from '@components/PageHeading';
 import { GuidanceText } from '@components/GuidanceText';
 import { ThemeAwareScreenOptions } from '@components/ThemeAwareScreenOptions';
 import { SafeAreaView } from 'react-native-safe-area-context';
-import { View, ScrollView, Dimensions } from 'react-native';
+import { View, ScrollView } from 'react-native';
 import { KeyboardAvoidingView } from 'react-native-keyboard-controller';
-import { useState } from 'react';
+import { useOrientation } from '@hooks/useOrientation';
 
 export default function PreGameConfigLayout() {
   // Retrieve Custom Properties
@@ -16,10 +16,7 @@ export default function PreGameConfigLayout() {
     colors: { background },
   } = useAppTheme();
 
-  const [isLandscape, setIsLandscape] = useState<boolean | null>(null);
-  Dimensions.addEventListener('change', ({ window }) => {
-    setIsLandscape(window.width > window.height);
-  });
+  const { isLandscape } = useOrientation();
 
   return (
     <SafeAreaView


### PR DESCRIPTION
Context: On device orientation change from Landscape to Portrait, `KeyboardAvoidingView` layout fails to resize to fill screen.

Action: Implement `useOrientation` hook to assign a dynamic `key` attribute on device rotation.

Result: Extracting the logic that forces React to unmount and remount the component to a hook isolates the state updates from the `_layout.tsx` render cycle allowing React to handle the remounting pipleine smoothly.

Notes: The hook uses `useWindowDimensions` hook in place of `Dimensions` for isolating layout logic to reduce boilerplate and risk of memory leaks; `Dimensions` would work too, but requires a `useEffect`, `.get('window')`, subscriptions references, and cleanup functions.

According to docs, `useWindowDimensions` doesn't rely on the React Native Bridge, but hooks directly into the core layout engine to avoid lags which, in this case, could cause `KeyboardAvoidingView`'s failure to stretch to fill the entire screen in portrait-mode.

Closes #176
Related #98 #101 #102 #143 #153 #163 #175